### PR TITLE
Update docs and API usage in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
 
 	logger.Println("Creating new cgm instance")
 
-	metrics, err := cgm.NewCirconusMetrics(cmc)
+	metrics, err := cgm.New(cmc)
 	if err != nil {
         logger.Println(err)
 		os.Exit(1)
@@ -148,7 +148,7 @@ func main() {
 
 	logger.Println("Creating new cgm instance")
 
-	metrics, err := cgm.NewCirconusMetrics(cmc)
+	metrics, err := cgm.New(cmc)
 	if err != nil {
         logger.Println(err)
 		os.Exit(1)
@@ -222,7 +222,7 @@ func main() {
     cmc := &cgm.Config{}
     cmc.CheckManager.API.TokenKey = os.Getenv("CIRCONUS_API_TOKEN")
 
-    metrics, err := cgm.NewCirconusMetrics(cmc)
+    metrics, err := cgm.New(cmc)
     if err != nil {
         panic(err)
     }

--- a/circonus-gometrics-impl_test.go
+++ b/circonus-gometrics-impl_test.go
@@ -1,0 +1,176 @@
+// Copyright 2016 Circonus, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package circonusgometrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testServer() *httptest.Server {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		// fmt.Printf("%s %s\n", r.Method, r.URL.String())
+		switch r.URL.Path {
+		case "/metrics_endpoint": // submit metrics
+			switch r.Method {
+			case "POST":
+				fallthrough
+			case "PUT":
+				defer r.Body.Close()
+				b, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					panic(err)
+				}
+				var ret []byte
+				var r interface{}
+				err = json.Unmarshal(b, &r)
+				if err != nil {
+					ret, err = json.Marshal(err)
+					if err != nil {
+						panic(err)
+					}
+				} else {
+					ret, err = json.Marshal(r)
+					if err != nil {
+						panic(err)
+					}
+				}
+				w.WriteHeader(200)
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, string(ret))
+			default:
+				w.WriteHeader(500)
+				fmt.Fprintln(w, "unsupported method")
+			}
+		default:
+			msg := fmt.Sprintf("not found %s", r.URL.Path)
+			w.WriteHeader(404)
+			fmt.Fprintln(w, msg)
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(f))
+}
+
+func TestNewImpl(t *testing.T) {
+	t.Log("no API token, submission URL only")
+	cfg := &Config{}
+	cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
+
+	cm, err := New(cfg)
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	trap, err := cm.check.GetTrap()
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	if trap.URL.String() != cfg.CheckManager.Check.SubmissionURL {
+		t.Fatalf("Expected '%s' == '%s'", trap.URL.String(), cfg.CheckManager.Check.SubmissionURL)
+	}
+
+	trap, err = cm.check.GetTrap()
+	if err != nil {
+		t.Fatalf("Expected no error, got '%v'", err)
+	}
+
+	if trap.URL.String() != cfg.CheckManager.Check.SubmissionURL {
+		t.Fatalf("Expected '%s' == '%s'", trap.URL.String(), cfg.CheckManager.Check.SubmissionURL)
+	}
+}
+
+func TestFlush(t *testing.T) {
+	server := testServer()
+	defer server.Close()
+
+	submissionURL := server.URL + "/metrics_endpoint"
+
+	t.Log("Already flushing")
+	{
+		cfg := &Config{}
+		cfg.CheckManager.Check.SubmissionURL = submissionURL
+		cm, err := New(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.flushing = true
+		cm.Flush()
+	}
+
+	t.Log("No metrics")
+	{
+		cfg := &Config{}
+		cfg.CheckManager.Check.SubmissionURL = submissionURL
+		cm, err := New(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.Flush()
+	}
+
+	t.Log("counter")
+	{
+		cfg := &Config{}
+		cfg.CheckManager.Check.SubmissionURL = submissionURL
+		cm, err := New(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.Set("foo", 30)
+
+		cm.Flush()
+	}
+
+	t.Log("gauge")
+	{
+		cfg := &Config{}
+		cfg.CheckManager.Check.SubmissionURL = submissionURL
+		cm, err := New(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.SetGauge("foo", 30)
+
+		cm.Flush()
+	}
+
+	t.Log("histogram")
+	{
+		cfg := &Config{}
+		cfg.CheckManager.Check.SubmissionURL = submissionURL
+		cm, err := New(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.Timing("foo", 30.28)
+
+		cm.Flush()
+	}
+
+	t.Log("text")
+	{
+		cfg := &Config{}
+		cfg.CheckManager.Check.SubmissionURL = submissionURL
+		cm, err := New(cfg)
+		if err != nil {
+			t.Errorf("Expected no error, got '%v'", err)
+		}
+
+		cm.SetText("foo", "bar")
+
+		cm.Flush()
+	}
+}

--- a/circonus-gometrics.go
+++ b/circonus-gometrics.go
@@ -73,7 +73,8 @@ type CirconusMetrics struct {
 	flushInterval   time.Duration
 	flushing        bool
 	flushmu         sync.Mutex
-	check           *checkmgr.CheckManager
+
+	check *checkmgr.CheckManager
 
 	counters map[string]uint64
 	cm       sync.Mutex

--- a/circonus-gometrics_test.go
+++ b/circonus-gometrics_test.go
@@ -2,69 +2,21 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package circonusgometrics
+package circonusgometrics_test
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
+
+	cgm "github.com/circonus-labs/circonus-gometrics"
 )
-
-func testServer() *httptest.Server {
-	f := func(w http.ResponseWriter, r *http.Request) {
-		// fmt.Printf("%s %s\n", r.Method, r.URL.String())
-		switch r.URL.Path {
-		case "/metrics_endpoint": // submit metrics
-			switch r.Method {
-			case "POST":
-				fallthrough
-			case "PUT":
-				defer r.Body.Close()
-				b, err := ioutil.ReadAll(r.Body)
-				if err != nil {
-					panic(err)
-				}
-				var ret []byte
-				var r interface{}
-				err = json.Unmarshal(b, &r)
-				if err != nil {
-					ret, err = json.Marshal(err)
-					if err != nil {
-						panic(err)
-					}
-				} else {
-					ret, err = json.Marshal(r)
-					if err != nil {
-						panic(err)
-					}
-				}
-				w.WriteHeader(200)
-				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintln(w, string(ret))
-			default:
-				w.WriteHeader(500)
-				fmt.Fprintln(w, "unsupported method")
-			}
-		default:
-			msg := fmt.Sprintf("not found %s", r.URL.Path)
-			w.WriteHeader(404)
-			fmt.Fprintln(w, msg)
-		}
-	}
-
-	return httptest.NewServer(http.HandlerFunc(f))
-}
 
 func TestNew(t *testing.T) {
 
 	t.Log("invalid config (none)")
 	{
 		expectedError := errors.New("invalid configuration (nil)")
-		_, err := New(nil)
+		_, err := cgm.New(nil)
 		if err == nil || err.Error() != expectedError.Error() {
 			t.Fatalf("Expected an '%#v' error, got '%#v'", expectedError, err)
 		}
@@ -72,41 +24,21 @@ func TestNew(t *testing.T) {
 
 	t.Log("no API token, no submission URL")
 	{
-		cfg := &Config{}
+		cfg := &cgm.Config{}
 		expectedError := errors.New("invalid check manager configuration (no API token AND no submission url)")
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err == nil || err.Error() != expectedError.Error() {
 			t.Fatalf("Expected an '%#v' error, got '%#v'", expectedError, err)
 		}
 	}
 
-	t.Log("no API token, submission URL only")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-
-		cm, err := New(cfg)
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		trap, err := cm.check.GetTrap()
-		if err != nil {
-			t.Fatalf("Expected no error, got '%v'", err)
-		}
-
-		if trap.URL.String() != cfg.CheckManager.Check.SubmissionURL {
-			t.Fatalf("Expected '%s' == '%s'", trap.URL.String(), cfg.CheckManager.Check.SubmissionURL)
-		}
-	}
-
 	t.Log("no Log, Debug = true")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			Debug: true,
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Fatalf("Expected no error, got '%v'", err)
 		}
@@ -114,22 +46,22 @@ func TestNew(t *testing.T) {
 
 	t.Log("flush interval [good]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			Interval: "30s",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("flush interval [bad]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			Interval: "thirty seconds",
 		}
 		expectedError := errors.New("time: invalid duration thirty seconds")
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -140,33 +72,33 @@ func TestNew(t *testing.T) {
 
 	t.Log("reset counters [good(true)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetCounters: "true",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset counters [good(1)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetCounters: "1",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset counters [bad(yes)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetCounters: "yes",
 		}
 		expectedError := errors.New("strconv.ParseBool: parsing \"yes\": invalid syntax")
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -177,33 +109,33 @@ func TestNew(t *testing.T) {
 
 	t.Log("reset gauges [good(true)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetGauges: "true",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset gauges [good(1)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetGauges: "1",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset gauges [bad(yes)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetGauges: "yes",
 		}
 		expectedError := errors.New("strconv.ParseBool: parsing \"yes\": invalid syntax")
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -214,33 +146,33 @@ func TestNew(t *testing.T) {
 
 	t.Log("reset histograms [good(true)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetHistograms: "true",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset histograms [good(1)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetHistograms: "1",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset histograms [bad(yes)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetHistograms: "yes",
 		}
 		expectedError := errors.New("strconv.ParseBool: parsing \"yes\": invalid syntax")
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -251,126 +183,38 @@ func TestNew(t *testing.T) {
 
 	t.Log("reset text metrics [good(true)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetText: "true",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset text metrics [good(1)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetText: "1",
 		}
 		cfg.CheckManager.Check.SubmissionURL = "http://127.0.0.1:56104/blah/blah"
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err != nil {
 			t.Errorf("Expected no error, got '%v'", err)
 		}
 	}
 	t.Log("reset text metrics [bad(yes)]")
 	{
-		cfg := &Config{
+		cfg := &cgm.Config{
 			ResetText: "yes",
 		}
 		expectedError := errors.New("strconv.ParseBool: parsing \"yes\": invalid syntax")
-		_, err := New(cfg)
+		_, err := cgm.New(cfg)
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		if err.Error() != expectedError.Error() {
 			t.Fatalf("Expected %v got '%v'", expectedError, err)
 		}
-	}
-}
-
-func TestFlush(t *testing.T) {
-	server := testServer()
-	defer server.Close()
-
-	submissionURL := server.URL + "/metrics_endpoint"
-
-	t.Log("Already flushing")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = submissionURL
-		cm, err := NewCirconusMetrics(cfg)
-		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
-		}
-
-		cm.flushing = true
-		cm.Flush()
-	}
-
-	t.Log("No metrics")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = submissionURL
-		cm, err := NewCirconusMetrics(cfg)
-		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
-		}
-
-		cm.Flush()
-	}
-
-	t.Log("counter")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = submissionURL
-		cm, err := NewCirconusMetrics(cfg)
-		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
-		}
-
-		cm.Set("foo", 30)
-
-		cm.Flush()
-	}
-
-	t.Log("gauge")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = submissionURL
-		cm, err := NewCirconusMetrics(cfg)
-		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
-		}
-
-		cm.SetGauge("foo", 30)
-
-		cm.Flush()
-	}
-
-	t.Log("histogram")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = submissionURL
-		cm, err := NewCirconusMetrics(cfg)
-		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
-		}
-
-		cm.Timing("foo", 30.28)
-
-		cm.Flush()
-	}
-
-	t.Log("text")
-	{
-		cfg := &Config{}
-		cfg.CheckManager.Check.SubmissionURL = submissionURL
-		cm, err := NewCirconusMetrics(cfg)
-		if err != nil {
-			t.Errorf("Expected no error, got '%v'", err)
-		}
-
-		cm.SetText("foo", "bar")
-
-		cm.Flush()
 	}
 }


### PR DESCRIPTION
Test the public interface in a standalone `_test.go` file and then spin off the private implementation checks into an `-impl_test.go` file that has the necessary visibility.  I didn't tease out the semantics of what was supposed to be happening in the `TestFlush()` call to see what could be split out.  The intent of this PR is two fold:

1) Document and use the public API in the docs and tests
2) Test the implementation in a smaller set of tests that are scoped to just testing the private API.  With the `Flush()` test it would be ideal to test in the public API test, however that would necessitate the creation of a `ForceFlush()` method or something like that, which is the only reason I didn't keep `Flush()` in the public API test function.

Feel free to reject this PR.