### PR TITLE
Centralize the various Config constants into a single place.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -27,6 +27,11 @@ const (
 	minRetryWait  = 1 * time.Second
 	maxRetryWait  = 15 * time.Second
 	maxRetries    = 4 // equating to 1 + maxRetries total attempts
+
+	AsyncMetrics     = CheckBundleConfigKey("async_metrics")
+	ReverseSecretKey = CheckBundleConfigKey("reverse:secret_key")
+	SecretKey        = CheckBundleConfigKey("secret")
+	SubmissionURL    = CheckBundleConfigKey("submission_url")
 )
 
 // TokenKeyType - Circonus API Token key

--- a/api/config/consts.go
+++ b/api/config/consts.go
@@ -1,0 +1,28 @@
+package config
+
+import "github.com/circonus-labs/circonus-gometrics/api"
+
+// Constants per type as defined in
+// https://login.circonus.com/resources/api/calls/check_bundle
+const (
+	// "http"
+	AuthMethod   api.CheckBundleConfigKey = "auth_method"
+	AuthPassword api.CheckBundleConfigKey = "auth_password"
+	AuthUser     api.CheckBundleConfigKey = "auth_user"
+	Body         api.CheckBundleConfigKey = "body"
+	CAChain      api.CheckBundleConfigKey = "ca_chain"
+	CertFile     api.CheckBundleConfigKey = "certificate_file"
+	Ciphers      api.CheckBundleConfigKey = "ciphers"
+	Code         api.CheckBundleConfigKey = "code"
+	Extract      api.CheckBundleConfigKey = "extract"
+	// HeaderPrefix is special because the actual key is dynamic and matches:
+	// `header_(\S+)`
+	HeaderPrefix api.CheckBundleConfigKey = "header_"
+	HTTPVersion  api.CheckBundleConfigKey = "http_version"
+	KeyFile      api.CheckBundleConfigKey = "key_file"
+	Method       api.CheckBundleConfigKey = "method"
+	Payload      api.CheckBundleConfigKey = "payload"
+	ReadLimit    api.CheckBundleConfigKey = "read_limit"
+	Redirects    api.CheckBundleConfigKey = "redirects"
+	URL          api.CheckBundleConfigKey = "url"
+)

--- a/checkmgr/check.go
+++ b/checkmgr/check.go
@@ -201,14 +201,13 @@ func (cm *CheckManager) initializeTrapURL() error {
 
 	// determine the trap url to which metrics should be PUT
 	if checkBundle.Type == "httptrap" {
-		cfgKey := api.CheckBundleConfigKey("submission_url")
-		if turl, found := checkBundle.Config[cfgKey]; found {
+		if turl, found := checkBundle.Config[api.SubmissionURL]; found {
 			cm.trapURL = api.URLType(turl)
 		} else {
 			if cm.Debug {
-				cm.Log.Printf("Missing config.%s %+v", cfgKey, checkBundle)
+				cm.Log.Printf("Missing config.%s %+v", api.SubmissionURL, checkBundle)
 			}
-			return fmt.Errorf("[ERROR] Unable to use check, no %s in config", cfgKey)
+			return fmt.Errorf("[ERROR] Unable to use check, no %s in config", api.SubmissionURL)
 		}
 	} else {
 		// build a submission_url for non-httptrap checks out of mtev_reverse url
@@ -218,14 +217,13 @@ func (cm *CheckManager) initializeTrapURL() error {
 		mtevURL := checkBundle.ReverseConnectURLs[0]
 		mtevURL = strings.Replace(mtevURL, "mtev_reverse", "https", 1)
 		mtevURL = strings.Replace(mtevURL, "check", "module/httptrap", 1)
-		cfgKey := api.CheckBundleConfigKey("reverse:secret_key")
-		if rs, found := checkBundle.Config[cfgKey]; found {
+		if rs, found := checkBundle.Config[api.ReverseSecretKey]; found {
 			cm.trapURL = api.URLType(fmt.Sprintf("%s/%s", mtevURL, rs))
 		} else {
 			if cm.Debug {
-				cm.Log.Printf("Missing config.%s %+v", cfgKey, checkBundle)
+				cm.Log.Printf("Missing config.%s %+v", api.ReverseSecretKey, checkBundle)
 			}
-			return fmt.Errorf("[ERROR] Unable to use check, no %s in config", cfgKey)
+			return fmt.Errorf("[ERROR] Unable to use check, no %s in config", api.ReverseSecretKey)
 		}
 	}
 
@@ -289,8 +287,8 @@ func (cm *CheckManager) createNewCheck() (*api.CheckBundle, *api.Broker, error) 
 	config := &api.CheckBundle{
 		Brokers: []string{broker.CID},
 		Config: map[api.CheckBundleConfigKey]string{
-			"async_metrics": "true",
-			"secret":        checkSecret,
+			api.AsyncMetrics: "true",
+			api.SecretKey:    checkSecret,
 		},
 		DisplayName: string(cm.checkDisplayName),
 		Metrics:     []api.CheckBundleMetric{},


### PR DESCRIPTION
It's now possible to find all referrers of a key to see where it is
used.  Bonus, compiler type safety.

Noticed while grep'ing around for other config parameters vs hitting the API docs page first.