### PR TITLE
Change Timeout to be of type `float64` to match the actual API which allows for fractional seconds.

### DIFF
--- a/api/check_bundle.go
+++ b/api/check_bundle.go
@@ -40,7 +40,7 @@ type CheckBundle struct {
 	LastModifedBy      string              `json:"_last_modifed_by,omitempty"`
 	ReverseConnectURLs []string            `json:"_reverse_connection_urls,omitempty"`
 	Brokers            []string            `json:"brokers"`
-	Config             CheckBundleConfig   `json:"config"`
+	Config             CheckBundleConfig   `json:"config,omitempty"`
 	DisplayName        string              `json:"display_name"`
 	Metrics            []CheckBundleMetric `json:"metrics"`
 	MetricLimit        int                 `json:"metric_limit,omitempty"`
@@ -49,7 +49,7 @@ type CheckBundle struct {
 	Status             string              `json:"status,omitempty"`
 	Tags               []string            `json:"tags,omitempty"`
 	Target             string              `json:"target"`
-	Timeout            int                 `json:"timeout,omitempty"`
+	Timeout            float64             `json:"timeout,omitempty"`
 	Type               string              `json:"type"`
 }
 


### PR DESCRIPTION
Also add `omitempty` to `config` to enhance the error messages returned
in the event that `config` is omitted.  See `timeout` at: https://login.circonus.com/resources/api/calls/check_bundle